### PR TITLE
Feature/auto execute

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [
-        .target(name: "DataLoader", dependencies: ["NIO"]),
+        .target(name: "DataLoader", dependencies: ["NIO", "NIOConcurrencyHelpers"]),
         .testTarget(name: "DataLoaderTests", dependencies: ["DataLoader"]),
     ],
     swiftLanguageVersions: [.v5]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Include this repo in your `Package.swift` file.
 To get started, create a DataLoader. Each DataLoader instance represents a unique cache. Typically instances are created per request when used
 within a web-server if different users can see different things.
 
-## Batching
+## Batching 🍪
 Batching is not an advanced feature, it's DataLoader's primary feature.
 
 Create a DataLoader by providing a batch loading function:
@@ -49,7 +49,7 @@ try userLoader.loadMany(keys: [1, 2, 3], on: eventLoopGroup)
 ```
 
 ### Execution
-By default, a DataLoader will wait for a short time (2ms) from the moment `load` is called to collect keys prior
+By default, a DataLoader will wait for a short time from the moment `load` is called to collect keys prior
 to running the `batchLoadFunction` and completing the `load` futures. This is to let keys accumulate and 
 batch into a smaller number of total requests. This amount of time is configurable using the `executionPeriod` 
 option:
@@ -70,15 +70,14 @@ If desired, you can manually execute the `batchLoadFunction` and complete the fu
 `.execute()` method.
 
 Scheduled execution can be disabled by setting `executionPeriod` to `nil`, but be careful - you *must* call `.execute()` 
-manually in this case. Otherwise, the futures will never complete.
+manually in this case. Otherwise, the futures will never complete!
 
 ### Disable batching
-It is possible to disable batching by setting the   `batchingEnabled` option to `false`
-It will invoke the `batchLoadFunction` immediately when a key is loaded.
+It is possible to disable batching by setting the   `batchingEnabled` option to `false`.
+In this case, the `batchLoadFunction` will be invoked immediately when a key is loaded.
 
 
-## Caching
-
+## Caching 💰
 DataLoader provides a memoization cache. After `.load()` is called with a key, the resulting value is cached 
 for the lifetime of the DataLoader object. This eliminates redundant loads.
 
@@ -89,7 +88,7 @@ relieve memory pressure on your application:
 let userLoader = DataLoader<Int, Int>(...)
 let future1 = userLoader.load(key: 1, on: eventLoopGroup)
 let future2 = userLoader.load(key: 1, on: eventLoopGroup)
-assert(future1 === future2)
+print(future1 == future2) // true
 ```
 
 ### Caching per-Request
@@ -123,7 +122,7 @@ let userLoader = DataLoader<Int, Int>(...)
 userLoader.load(key: 4, on: eventLoopGroup)
 
 // A mutation occurs, invalidating what might be in cache.
-sqlRun('UPDATE users WHERE id=4 SET username="zuck"').then { userLoader.clear(4) }
+sqlRun('UPDATE users WHERE id=4 SET username="zuck"').whenComplete { userLoader.clear(key: 4) }
 
 // Later the value load is loaded again so the mutated data appears.
 userLoader.load(key: 4, on: eventLoopGroup)
@@ -141,7 +140,7 @@ be cached to avoid frequently loading the same `Error`.
 In some circumstances you may wish to clear the cache for these individual Errors:
 
 ```swift
-userLoader.load(key: 1, on: eventLoopGroup).catch { error in {
+userLoader.load(key: 1, on: eventLoopGroup).whenFailure { error in 
     if (/* determine if should clear error */) {
         userLoader.clear(key: 1);
     }
@@ -191,7 +190,7 @@ let myLoader = DataLoader<String, String>(batchLoadFunction: { keys in
 })
 ```
 
-## Using with GraphQL
+## Using with GraphQL 🎀
 
 DataLoader pairs nicely well with [GraphQL](https://github.com/GraphQLSwift/GraphQL) and
 [Graphiti](https://github.com/GraphQLSwift/Graphiti). GraphQL fields are designed to be 
@@ -219,7 +218,7 @@ Consider the following GraphQL request:
 ```
 
 Naively, if `me`, `bestFriend` and `friends` each need to request the backend,
-there could be at most 13 database requests!
+there could be at most 12 database requests!
 
 By using DataLoader, we could batch our requests to a `User` type, and 
 only require at most 4 database requests, and possibly fewer if there are cache hits.
@@ -252,8 +251,8 @@ struct UserResolver {
 
 class UserContext {
     let database = ...
-    let userLoader = DataLoader<Int, User>() { keys in
-        return User.query(on: database).filter(\.$id ~~ keys).all().map { users in
+    let userLoader = DataLoader<Int, User>() { [unowned self] keys in
+        return User.query(on: self.database).filter(\.$id ~~ keys).all().map { users in
             keys.map { key in
                 users.first { $0.id == key }!
             }
@@ -284,8 +283,8 @@ struct UserAPI : API {
 All your feedback and help to improve this project is very welcome. Please create issues for your bugs, ideas and
 enhancement requests, or better yet, contribute directly by creating a PR. 😎
 
-When reporting an issue, please add a detailed instruction, and if possible a code snippet or test that can be used
-as a reproducer of your problem. 💥
+When reporting an issue, please add a detailed example, and if possible a code snippet or test
+to reproduce your problem. 💥
 
 When creating a pull request, please adhere to the current coding style where possible, and create tests with your
 code so it keeps providing an awesome test coverage level 💪

--- a/Sources/DataLoader/DataLoaderOptions.swift
+++ b/Sources/DataLoader/DataLoaderOptions.swift
@@ -1,3 +1,5 @@
+import NIO
+
 public struct DataLoaderOptions<Key: Hashable, Value> {
     /// Default `true`. Set to `false` to disable batching, invoking
     /// `batchLoadFunction` with a single load key. This is
@@ -13,6 +15,13 @@ public struct DataLoaderOptions<Key: Hashable, Value> {
     /// for every load of the same key.
     public let cachingEnabled: Bool
     
+    /// Default `2ms`. Defines the period of time that the DataLoader should
+    /// wait and collect its queue before executing. Faster times result
+    /// in smaller batches quicker resolution, slower times result in larger
+    /// batches but slower resolution.
+    /// This is irrelevant if batching is disabled.
+    public let executionPeriod: TimeAmount?
+    
     /// Default `nil`. Produces cache key for a given load key. Useful
     /// when objects are keys and two objects should be considered equivalent.
     public let cacheKeyFunction: ((Key) -> Key)?
@@ -20,9 +29,12 @@ public struct DataLoaderOptions<Key: Hashable, Value> {
     public init(batchingEnabled: Bool = true,
                 cachingEnabled: Bool = true,
                 maxBatchSize: Int? = nil,
-                cacheKeyFunction: ((Key) -> Key)? = nil) {
+                executionPeriod: TimeAmount? = .milliseconds(2),
+                cacheKeyFunction: ((Key) -> Key)? = nil
+    ) {
         self.batchingEnabled = batchingEnabled
         self.cachingEnabled = cachingEnabled
+        self.executionPeriod = executionPeriod
         self.maxBatchSize = maxBatchSize
         self.cacheKeyFunction = cacheKeyFunction
     }

--- a/Sources/DataLoader/DataLoaderOptions.swift
+++ b/Sources/DataLoader/DataLoaderOptions.swift
@@ -13,8 +13,6 @@ public struct DataLoaderOptions<Key: Hashable, Value> {
     /// for every load of the same key.
     public let cachingEnabled: Bool
     
-    public let cacheMap: [Key: Value]
-    
     /// Default `nil`. Produces cache key for a given load key. Useful
     /// when objects are keys and two objects should be considered equivalent.
     public let cacheKeyFunction: ((Key) -> Key)?
@@ -22,12 +20,10 @@ public struct DataLoaderOptions<Key: Hashable, Value> {
     public init(batchingEnabled: Bool = true,
                 cachingEnabled: Bool = true,
                 maxBatchSize: Int? = nil,
-                cacheMap: [Key: Value] = [:],
                 cacheKeyFunction: ((Key) -> Key)? = nil) {
         self.batchingEnabled = batchingEnabled
         self.cachingEnabled = cachingEnabled
         self.maxBatchSize = maxBatchSize
-        self.cacheMap = cacheMap
         self.cacheKeyFunction = cacheKeyFunction
     }
 }

--- a/Tests/DataLoaderTests/DataLoaderAbuseTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAbuseTests.swift
@@ -12,13 +12,13 @@ class DataLoaderAbuseTests: XCTestCase {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
 
-        let identityLoader = DataLoader<Int, Int>(options: DataLoaderOptions(batchingEnabled: false)) { keys in
+        let identityLoader = DataLoader<Int, Int>(
+            options: DataLoaderOptions(batchingEnabled: false)
+        ) { keys in
             eventLoopGroup.next().makeSucceededFuture([])
         }
 
         let value = try identityLoader.load(key: 1, on: eventLoopGroup)
-
-        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value.wait(), "Did not return value for key: 1")
     }
@@ -29,13 +29,11 @@ class DataLoaderAbuseTests: XCTestCase {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
 
-        let identityLoader = DataLoader<Int, Int>(options: DataLoaderOptions()) { keys in
+        let identityLoader = DataLoader<Int, Int>() { keys in
             eventLoopGroup.next().makeSucceededFuture([])
         }
 
         let value = try identityLoader.load(key: 1, on: eventLoopGroup)
-
-        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value.wait(), "The function did not return an array of the same length as the array of keys. \nKeys count: 1\nValues count: 0")
     }
@@ -46,7 +44,7 @@ class DataLoaderAbuseTests: XCTestCase {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
 
-        let identityLoader = DataLoader<Int, Int>(options: DataLoaderOptions()) { keys in
+        let identityLoader = DataLoader<Int, Int>() { keys in
             var results = [DataLoaderFutureValue<Int>]()
 
             for key in keys {
@@ -62,8 +60,6 @@ class DataLoaderAbuseTests: XCTestCase {
 
         let value1 = try identityLoader.load(key: 1, on: eventLoopGroup)
         let value2 = try identityLoader.load(key: 2, on: eventLoopGroup)
-
-        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value2.wait())
 
@@ -76,7 +72,9 @@ class DataLoaderAbuseTests: XCTestCase {
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
         }
 
-        let identityLoader = DataLoader<Int, Int>(options: DataLoaderOptions(batchingEnabled: false)) { keys in
+        let identityLoader = DataLoader<Int, Int>(
+            options: DataLoaderOptions(batchingEnabled: false)
+        ) { keys in
             var results = [DataLoaderFutureValue<Int>]()
 
             for key in keys {
@@ -92,8 +90,6 @@ class DataLoaderAbuseTests: XCTestCase {
 
         let value1 = try identityLoader.load(key: 1, on: eventLoopGroup)
         let value2 = try identityLoader.load(key: 2, on: eventLoopGroup)
-
-        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value2.wait())
 

--- a/Tests/DataLoaderTests/DataLoaderAbuseTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAbuseTests.swift
@@ -18,7 +18,7 @@ class DataLoaderAbuseTests: XCTestCase {
 
         let value = try identityLoader.load(key: 1, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value.wait(), "Did not return value for key: 1")
     }
@@ -35,7 +35,7 @@ class DataLoaderAbuseTests: XCTestCase {
 
         let value = try identityLoader.load(key: 1, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value.wait(), "The function did not return an array of the same length as the array of keys. \nKeys count: 1\nValues count: 0")
     }
@@ -63,7 +63,7 @@ class DataLoaderAbuseTests: XCTestCase {
         let value1 = try identityLoader.load(key: 1, on: eventLoopGroup)
         let value2 = try identityLoader.load(key: 2, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value2.wait())
 
@@ -93,20 +93,12 @@ class DataLoaderAbuseTests: XCTestCase {
         let value1 = try identityLoader.load(key: 1, on: eventLoopGroup)
         let value2 = try identityLoader.load(key: 2, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertThrowsError(try value2.wait())
 
         XCTAssertTrue(try value1.wait() == 1)
     }
-
-    static var allTests: [(String, (DataLoaderAbuseTests) -> () throws -> Void)] = [
-        ("testFuntionWithNoValues", testFuntionWithNoValues),
-        ("testBatchFuntionMustPromiseAnArrayOfCorrectLength", testBatchFuntionMustPromiseAnArrayOfCorrectLength),
-        ("testBatchFuntionWithSomeValues", testBatchFuntionWithSomeValues),
-        ("testFuntionWithSomeValues", testFuntionWithSomeValues)
-    ]
-    
 }
 
 extension String: Error { }

--- a/Tests/DataLoaderTests/DataLoaderTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderTests.swift
@@ -21,7 +21,7 @@ final class DataLoaderTests: XCTestCase {
 
         let value = try identityLoader.load(key: 1, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value.wait() == 1)
     }
@@ -41,7 +41,7 @@ final class DataLoaderTests: XCTestCase {
 
         let values = try identityLoader.loadMany(keys: [1, 2], on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try values.wait() == [1,2])
 
@@ -69,7 +69,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: 1, on: eventLoopGroup)
         let value2 = try identityLoader.load(key: 2, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.map { $0 }.wait() == 1)
         XCTAssertTrue(try value2.map { $0 }.wait() == 2)
@@ -97,7 +97,7 @@ final class DataLoaderTests: XCTestCase {
         let value2 = try identityLoader.load(key: 2, on: eventLoopGroup)
         let value3 = try identityLoader.load(key: 3, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.map { $0 }.wait() == 1)
         XCTAssertTrue(try value2.map { $0 }.wait() == 2)
@@ -125,7 +125,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: 1, on: eventLoopGroup)
         let value2 = try identityLoader.load(key: 1, on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.map { $0 }.wait() == 1)
         XCTAssertTrue(try value2.map { $0 }.wait() == 1)
@@ -152,7 +152,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value2 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.wait() == "A")
         XCTAssertTrue(try value2.wait() == "B")
@@ -161,7 +161,7 @@ final class DataLoaderTests: XCTestCase {
         let value3 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value4 = try identityLoader.load(key: "C", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value3.wait() == "A")
         XCTAssertTrue(try value4.wait() == "C")
@@ -172,7 +172,7 @@ final class DataLoaderTests: XCTestCase {
         let value7 = try identityLoader.load(key: "C", on: eventLoopGroup)
 
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value5.wait() == "A")
         XCTAssertTrue(try value6.wait() == "B")
@@ -199,7 +199,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value2 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.wait() == "A")
         XCTAssertTrue(try value2.wait() == "B")
@@ -210,7 +210,7 @@ final class DataLoaderTests: XCTestCase {
         let value3 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value4 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value3.wait() == "A")
         XCTAssertTrue(try value4.wait() == "B")
@@ -236,7 +236,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value2 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.wait() == "A")
         XCTAssertTrue(try value2.wait() == "B")
@@ -247,7 +247,7 @@ final class DataLoaderTests: XCTestCase {
         let value3 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value4 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value3.wait() == "A")
         XCTAssertTrue(try value4.wait() == "B")
@@ -275,7 +275,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value2 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.wait() == "A")
         XCTAssertTrue(try value2.wait() == "B")
@@ -303,7 +303,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value2 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.wait() == "X")
         XCTAssertTrue(try value2.wait() == "B")
@@ -314,7 +314,7 @@ final class DataLoaderTests: XCTestCase {
         let value3 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value4 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value3.wait() == "X")
         XCTAssertTrue(try value4.wait() == "B")
@@ -343,7 +343,7 @@ final class DataLoaderTests: XCTestCase {
         let value1 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value2 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value1.wait() == "X")
         XCTAssertTrue(try value2.wait() == "B")
@@ -354,7 +354,7 @@ final class DataLoaderTests: XCTestCase {
         let value3 = try identityLoader.load(key: "A", on: eventLoopGroup)
         let value4 = try identityLoader.load(key: "B", on: eventLoopGroup)
 
-        XCTAssertNoThrow(try identityLoader.dispatchQueue(on: eventLoopGroup))
+        XCTAssertNoThrow(try identityLoader.execute())
 
         XCTAssertTrue(try value3.wait() == "Y")
         XCTAssertTrue(try value4.wait() == "Y")


### PR DESCRIPTION
New features:

* It adds support for concurrent access to the DataLoaders, which is important as GraphQL resolvers fan out asynchronously. This makes it possible to use a single DataLoader across all resolvers, which gets us the largest benefit from the caching and batching capabilities.
* DataLoader instances now have an `executionPeriod` option (enabled by default) that schedules an automatic execution of the queue, which was requested in #7. This means the client no longer has to call `dispatchQueue` (now `execute`) manually, which was difficult to do efficiently across GraphQL resolvers. The API here is inspired by the [go version](https://github.com/vektah/dataloaden#getting-started).
* An example using Graphiti and DataLoader was added to the readme

Apart from that, there's some minor refactoring and renaming.

Note that this does change the public API, so it should result in a major version increment.