### PR TITLE
Fixes handling of throwing batch load funcs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "b8368b6e09b7993896c42a6199103a73ecc1dbf9",
-          "version": "2.0.0"
+          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
+          "version": "2.37.0"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ struct UserResolver {
 
 class UserContext {
     let database = ...
-    let userLoader = DataLoader<Int, User>() { [unowned self] keys in
+    let userLoader = DataLoader<Int, User>() { [weak self] keys in
+        guard let self = self else { throw ContextError }
         return User.query(on: self.database).filter(\.$id ~~ keys).all().map { users in
             keys.map { key in
                 users.first { $0.id == key }!


### PR DESCRIPTION
While a batchLoadFunction was allowed to be throwing, if one threw it either caused deadlocks or an abandoned NIO future error.

These changes allow the batchLoadFunction to error, in which case all key futures are failed.