### PR TITLE
Adding async await to DataLoader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Build
         run: swift build
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: fwal/setup-swift@v1
+      - uses: swift-actions/setup-swift@v1
       - name: Build
         run: swift build
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,28 @@ on:
   pull_request:
     branches: [ master ]
 jobs:
-  build:
+  linux-build:
     name: Build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: swift-actions/setup-swift@v1
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
+  macos-build:
+    name: Build and test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: maxim-lobanov/setup-xcode@v1
       - name: Build
         run: swift build
       - name: Run tests

--- a/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
@@ -89,7 +89,7 @@ final class DataLoaderAsyncTests: XCTestCase {
         async let value2 = identityLoader.load(key: 2, on: eventLoopGroup)
         
         /// Have to wait for a split second because Tasks may not be executed before this statement
-        try await Task.sleep(nanoseconds: 500_000)
+        try await Task.sleep(nanoseconds: 500_000_000)
         
         XCTAssertNoThrow(try identityLoader.execute())
         

--- a/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
@@ -109,7 +109,8 @@ final class DataLoaderAsyncTests: XCTestCase {
         XCTAssertEqual(result2, 2)
 
         let calls = await loadCalls.wrappedValue
-        XCTAssertEqual(calls, [[1,2]])
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls.map { $0.sorted() }, [[1, 2]])
     }
 }
 

--- a/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+import NIO
+
+@testable import DataLoader
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+/// Primary API
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+final class DataLoaderAsyncTests: XCTestCase {
+
+    /// Builds a really really simple data loader with async await
+    func testReallyReallySimpleDataLoader() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+        }
+
+        let identityLoader = DataLoader<Int, Int>(
+            on: eventLoopGroup.next(),
+            options: DataLoaderOptions(batchingEnabled: false)
+        ) { keys async in
+            let task = Task {
+                keys.map { DataLoaderFutureValue.success($0) }
+            }
+            return await task.value
+        }
+
+        let value = try await identityLoader.load(key: 1, on: eventLoopGroup)
+
+        XCTAssertEqual(value, 1)
+    }
+
+    /// Supports loading multiple keys in one call
+    func testLoadingMultipleKeys() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+        }
+
+        let identityLoader = DataLoader<Int, Int>(on: eventLoopGroup.next()) { keys in
+            let task = Task {
+                keys.map { DataLoaderFutureValue.success($0) }
+            }
+            return await task.value
+        }
+
+        let values = try await identityLoader.loadMany(keys: [1, 2], on: eventLoopGroup)
+
+        XCTAssertEqual(values, [1,2])
+
+        let empty = try await identityLoader.loadMany(keys: [], on: eventLoopGroup)
+
+        XCTAssertTrue(empty.isEmpty)
+    }
+
+    // Batches multiple requests
+    func testMultipleRequests() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+        }
+
+        actor LoadCalls {
+            var loadCalls = [[Int]]()
+
+            func append(_ calls: [Int]) {
+                loadCalls.append(calls)
+            }
+
+            static let shared: LoadCalls = .init()
+        }
+
+        let identityLoader = DataLoader<Int, Int>(
+            on: eventLoopGroup.next(),
+            options: DataLoaderOptions(
+                batchingEnabled: true,
+                executionPeriod: nil
+            )
+        ) { keys in
+            await LoadCalls.shared.append(keys)
+            let task = Task {
+                keys.map { DataLoaderFutureValue.success($0) }
+            }
+            return await task.value
+        }
+
+        async let value1 = identityLoader.load(key: 1, on: eventLoopGroup)
+        async let value2 = identityLoader.load(key: 2, on: eventLoopGroup)
+        
+        /// Have to wait for a split second because Tasks may not be executed before this statement
+        try await Task.sleep(nanoseconds: 500_000)
+        
+        XCTAssertNoThrow(try identityLoader.execute())
+        
+        let result1 = try await value1
+        XCTAssertEqual(result1, 1)
+        let result2 = try await value2
+        XCTAssertEqual(result2, 2)
+
+        let loadCalls = await LoadCalls.shared.loadCalls
+        XCTAssertEqual(loadCalls, [[1,2]])
+    }
+}
+
+#endif


### PR DESCRIPTION
This pull request simply adds extensions to use DataLoader with async await.

This also includes test cases using these async await extensions derived from `DataLoaderTests`, but without some test cases as it seemed redundant.

Another thing to note is that the `ConcurrentBatchLoadFunction` is set to be `Sendable`, which makes sure it is concurrent safe. I think it makes a lot of sense in this case.