### PR TITLE
chore: Adjusts format CI to use docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ jobs:
     name: Format linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: sinoru/actions-setup-swift@v2
-        with:
-          swift-version: '5.6.1'
-      - name: GitHub Action for SwiftFormat
-        uses: CassiusPacheco/action-swiftformat@v0.1.0
-        with:
-          swiftformat-version: '0.49.17'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Pull formatting docker image
+        run: docker pull ghcr.io/nicklockwood/swiftformat:latest
+      - name: Run format linting
+        run: docker run --rm -v ${{ github.workspace }}:/repo ghcr.io/nicklockwood/swiftformat:latest /repo --lint
   macos-build:
     name: Build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,18 +33,35 @@ jobs:
         run: swift build
       - name: Run tests
         run: swift test
-  linux-build:
-    name: Build and test ${{ matrix.swift }}  on ${{ matrix.os }}
+        
+  # ubuntu-latest is ubuntu-22.04 currently. Swift versions older than 5.7 don't have builds for 22.04. https://www.swift.org/download/ 
+  ubuntu-old:
+    name: Build ${{ matrix.swift }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04] 
         swift: ["5.4", "5.5", "5.6"]
     steps:
-      - uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: ${{ matrix.swift }}
-      - uses: actions/checkout@v2
-      - name: Test
-        run: swift test
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: ${{ matrix.swift }}
+    - uses: actions/checkout@v3
+    - name: Test
+      run: swift test
+
+  ubuntu-latest:
+    name: Build ${{ matrix.swift }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest] 
+        swift: ["5.7"]
+    steps:
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: ${{ matrix.swift }}
+    - uses: actions/checkout@v3
+    - name: Test
+      run: swift test
 

--- a/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
@@ -96,7 +96,8 @@ import XCTest
             async let value1 = identityLoader.load(key: 1, on: eventLoopGroup)
             async let value2 = identityLoader.load(key: 2, on: eventLoopGroup)
 
-            /// Have to wait for a split second because Tasks may not be executed before this statement
+            /// Have to wait for a split second because Tasks may not be executed before this
+            /// statement
             try await Task.sleep(nanoseconds: 500_000_000)
 
             XCTAssertNoThrow(try identityLoader.execute())


### PR DESCRIPTION
This was done because the [swiftformat action](https://github.com/CassiusPacheco/action-swiftformat/blob/main/action.yml) was unable to run in `lint` mode, so contributors didn't know what formatting must be fixed.