### PR TITLE
refactor: use standardized swift-async-algorithms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           --format html \
           --output-dir=.test-coverage
     - name: Upload test coverage html
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-coverage-report
         path: .test-coverage

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,21 @@
 {
   "pins" : [
     {
-      "identity" : "async-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/adam-fowler/async-collections",
-      "state" : {
-        "revision" : "726af96095a19df6b8053ddbaed0a727aa70ccb2",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "swift-algorithms",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
         "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "4c3ea81f81f0a25d0470188459c6d4bf20cf2f97",
+        "version" : "1.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
-        .package(url: "https://github.com/adam-fowler/async-collections", from: "0.0.1"),
+        .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [
@@ -27,7 +27,7 @@ let package = Package(
             name: "AsyncDataLoader",
             dependencies: [
                 .product(name: "Algorithms", package: "swift-algorithms"),
-                .product(name: "AsyncCollections", package: "async-collections"),
+                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
             ]
         ),
         .testTarget(name: "DataLoaderTests", dependencies: ["DataLoader"]),


### PR DESCRIPTION
Adopts the more common (now-a-days) swift-async-algorithms for the simple async collection needs of this package. Helps adopt the standardized ecosystem where many other packages use swift-async-algorithms.